### PR TITLE
Configurable headers and footers in BUILD files

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,18 @@ By default, `pazel` adds rules to install all external Python packages. If your 
 pre-installed packages for which these rules are not required, then use `pazel -p`.
 
 
-### Working with custom Bazel rules and ignoring rules in existing BUILD files
+### Ignoring rules in existing BUILD files
 
-The tag `# pazel-ignore` causes `pazel` to ignore the rule that immediately follows it in an
-existing BUILD file. See `sample_app/foo/BUILD` for an example using the tag.
-This feature can be applied to custom rules, in particular. `pazel` places the ignored rules
-at the bottom of the BUILD file.
+The tag `# pazel-ignore` causes `pazel` to ignore the rule that immediately follows the tag in an
+existing BUILD file. In particular, the tag can be used to skip custom rules that `pazel` does not 
+handle. `pazel` places the ignored rules at the bottom of the BUILD file. See `sample_app/foo/BUILD`
+for an example using the tag.
+
+
+### Customizing and extending pazel
+
+`pazel` can be programmed using a `.pazelrc` Python file that should be located in the project root
+(defaults to the current working directory but can be changed with the flag `pazel -r <some_path>`).
+
+The user can define variables `HEADER` and `FOOTER` to add custom header and footer to all
+BUILD files, respectively. See `sample_app/.pazelrc` and `sample_app/BUILD` for an example.

--- a/pazel/app.py
+++ b/pazel/app.py
@@ -13,6 +13,7 @@ from pazel.helpers import is_ignored
 from pazel.helpers import is_python_file
 from pazel.output_build import output_build_file
 from pazel.parse_build import get_ignored_rules
+from pazel.pazel_extensions import parse_pazel_extensions
 
 
 def app(input_path, project_root, contains_pre_installed_packages):
@@ -28,6 +29,9 @@ def app(input_path, project_root, contains_pre_installed_packages):
     Raises:
         RuntimeError: input_path does is not a directory or a Python file.
     """
+    # Parse user-defined extensions to pazel.
+    extensions = parse_pazel_extensions(project_root)
+
     # Handle directories.
     if os.path.isdir(input_path):
         # Traverse the directory recursively.
@@ -50,7 +54,7 @@ def app(input_path, project_root, contains_pre_installed_packages):
 
             # If Python files were found, output the BUILD file.
             if build_source != '':
-                output_build_file(build_source, ignored_rules, build_file_path)
+                output_build_file(build_source, ignored_rules, extensions, build_file_path)
     # Handle single Python file.
     elif is_python_file(input_path):
         # Parse ignored rules in an existing BUILD file, if any.
@@ -62,7 +66,7 @@ def app(input_path, project_root, contains_pre_installed_packages):
             build_source = parse_script_and_generate_rule(input_path, project_root,
                                                           contains_pre_installed_packages)
 
-            output_build_file(build_source, ignored_rules, build_file_path)
+            output_build_file(build_source, ignored_rules, extensions, build_file_path)
     else:
         raise RuntimeError("Invalid input path %s." % input_path)
 

--- a/pazel/output_build.py
+++ b/pazel/output_build.py
@@ -6,35 +6,37 @@ from __future__ import print_function
 
 
 # Used for installing pip packages. See https://github.com/bazelbuild/rules_python
-REQUIREMENT = """
-load("@my_deps//:requirements.bzl", "requirement")"""
-
-HEADER = """package(default_visibility = ["//visibility:public"]){requirement}
-
-"""
+REQUIREMENT = """load("@my_deps//:requirements.bzl", "requirement")"""
 
 
-def output_build_file(build_source, ignored_rules, build_file_path):
+def _append_newline(source):
+    """Add newline to a string if it does not end with a newline."""
+    return source if source.endswith('\n') else source + '\n'
+
+
+def output_build_file(build_source, ignored_rules, extensions, build_file_path):
     """Output a BUILD file.
 
     Args:
         build_source (str): The contents of the BUILD file to output.
         ignored_rules (list of str): Rules the user wants to keep as is.
+        extensions (PazelExtension): User-defined extensions to pazel.
         build_file_path (str): Path to the BUILD file in which build_source is written.
     """
+    header = _append_newline(extensions.header)
+
     # If the BUILD file contains external packages, add the Bazel method for installing them.
     if 'requirement("' in build_source:
-        requirement = REQUIREMENT
-    else:
-        requirement = ''
+        header += _append_newline(REQUIREMENT)
 
-    header = HEADER.format(requirement=requirement)
-    build_source = header + build_source
+    build_source = header + '\n' + build_source
 
     # Add ignored rules to the bottom, separated by newlines.
     if ignored_rules:
         build_source = build_source.rstrip()
-        build_source += '\n' + '\n'.join(ignored_rules) + '\n'
+        build_source += '\n' + '\n'.join(ignored_rules) + 2*'\n'
+
+    build_source += _append_newline(extensions.footer)
 
     with open(build_file_path, 'w') as build_file:
         build_file.write(build_source)

--- a/pazel/pazel_extensions.py
+++ b/pazel/pazel_extensions.py
@@ -1,0 +1,70 @@
+"""Handle user-defined pazel extensions."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import ast
+import os
+
+
+PAZELRC_FILE = '.pazelrc'
+
+
+class PazelExtension(object):
+    """A class representing pazel extensions."""
+
+    def __init__(self, header, footer):
+        """Instantiate.
+
+        Args:
+            header (str): Header for BUILD files.
+            footer (str): Footer for BUILD files.
+        """
+        self.header = header
+        self.footer = footer
+
+
+def parse_pazel_extensions(directory):
+    """Parse pazel extensions from a .pazelrc file.
+
+    Args:
+        directory (str): Path to a directory that may contain a .pazelrc file.
+
+    Returns:
+        extension (PazelExtension): Object containing user-defined extensions.
+
+    Raises:
+        SyntaxError: If the .pazelrc contains invalid Python syntax.
+    """
+    pazelrc_path = os.path.join(directory, PAZELRC_FILE)
+
+    header = ''
+    footer = ''
+
+    try:
+        with open(pazelrc_path, 'r') as pazelrc:
+            pazel_extensions_source = pazelrc.read()
+    except IOError:
+        return PazelExtension(header, footer)
+
+    try:
+        top_node = ast.parse(pazel_extensions_source)
+    except SyntaxError:
+        raise SyntaxError("Invalid syntax in %s." % pazelrc_path)
+
+    for node in top_node.body:
+        # Check assigning to 'HEADER' and 'FOOTER'.
+        if isinstance(node, ast.Assign):
+            # The number of variables on the left side should be 1.
+            if len(node.targets) == 1:
+                left_side = node.targets[0].id
+
+                if left_side == 'HEADER':
+                    header = node.value.s
+                elif left_side == 'FOOTER':
+                    footer = node.value.s
+
+    extension = PazelExtension(header, footer)
+
+    return extension

--- a/pazel/tests/test_helpers.py
+++ b/pazel/tests/test_helpers.py
@@ -10,8 +10,10 @@ from pazel.helpers import parse_enclosed_expression
 
 
 class TestHelpers(unittest.TestCase):
+    """Test helper functions."""
 
     def test_parse_enclosed_expression(self):
+        """Test parse_enclosed_expression."""
         expected_expression = """py_library(
             name = "foo",
             srcs = ["foo.py"],

--- a/sample_app/.pazelrc
+++ b/sample_app/.pazelrc
@@ -1,0 +1,5 @@
+"""Define pazel extensions for this directory and its subdirectories unless overriden elsewhere."""
+
+HEADER = """package(default_visibility = ["//visibility:public"])"""
+
+FOOTER = """# My footer"""

--- a/sample_app/BUILD
+++ b/sample_app/BUILD
@@ -6,3 +6,4 @@ py_library(
     deps = [],
 )
 
+# My footer

--- a/sample_app/foo/BUILD
+++ b/sample_app/foo/BUILD
@@ -42,3 +42,5 @@ py_test(    # pazel would mark bar4.py as a library but it remains as a test bec
 custom_rule("bar5",  # pazel recognizes positional arguments, too.
             "bar5.py"
 )
+
+# My footer

--- a/sample_app/tests/BUILD
+++ b/sample_app/tests/BUILD
@@ -33,3 +33,4 @@ py_test(
     data = glob(["test_data/*.png"])
 )
 
+# My footer

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,22 @@
+"""Entrypoint for starting with pazel.
+
+Run:
+
+`python setup.py install` to install pazel.
+`python setup.py develop` to develop pazel.
+`python setup.py test` to run pazel tests.
+"""
+
 from setuptools import setup, find_packages
 
-description = "Generate Bazel BUILD files for a Python project."
+DESCRIPTION = "Generate Bazel BUILD files for a Python project."
 
 setup(
     name='pazel',
     version='0.1.0',
-    description=description,
+    description=DESCRIPTION,
     packages=find_packages(exclude=('sample_app', 'sample_app.foo', 'sample_app.tests')),
-    entry_points = {
+    entry_points={
         'console_scripts': ['pazel = pazel.app:main']
     },
     test_suite='pazel.tests'


### PR DESCRIPTION
- Introduce .pazelrc file for programming pazel
- Allow configuring headers and footers in BUILD files
- Configuration is done using .pazelrc file in the project root
- Describe the feature in README
- Fix pep8/257 issues