### PR TITLE
Add support for parsing imports from public API

### DIFF
--- a/sample_app/foo/BUILD
+++ b/sample_app/foo/BUILD
@@ -4,7 +4,7 @@ load("@my_deps//:requirements.bzl", "requirement")
 py_library(
     name = "__init__",
     srcs = ["__init__.py"],
-    deps = [],
+    deps = ["//foo:bar1"],
 )
 
 py_library(

--- a/sample_app/foo/__init__.py
+++ b/sample_app/foo/__init__.py
@@ -1,0 +1,3 @@
+from foo.bar1 import sample
+
+__all__ = ('sample', )

--- a/sample_app/xyz/BUILD
+++ b/sample_app/xyz/BUILD
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+py_binary(
+    name = "abc1",
+    srcs = ["abc1.py"],
+    deps = ["//foo:__init__"],
+)
+
+# My footer

--- a/sample_app/xyz/abc1.py
+++ b/sample_app/xyz/abc1.py
@@ -1,0 +1,8 @@
+from foo import sample  # Import from foo's public interface.
+
+
+def main():
+    print(sample())
+
+
+main()


### PR DESCRIPTION
- Generate correct dependencies for importing from the "public" interface
of a package as declared by __all__ of __init__.py of the package
- Update sample_app with an example that imports from such a public
interface