### PR TITLE
Support for local packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,11 @@ adds the same `visibility` to all BUILD files.
 
 If some pip package has different install name than import name, then the user
 should define `EXTRA_IMPORT_NAME_TO_PIP_NAME` dictionary accordingly. `sample_app/.pazelrc` has
-`{'yaml': 'pyyaml'}` as an example.
+`{'yaml': 'pyyaml'}` as an example. In addition, the user can specify local packages and their
+corresponding Bazel dependencies using the `EXTRA_LOCAL_IMPORT_NAME_TO_DEP` dictionary.
 
-The user can define custom Bazel rules by adding a new `Rule` class to `.pazelrc`.
-`sample_app/.pazelrc` defines a custom `PyDoctestRule` class that identifies all doctests and
-generates custom `py_doctest` Bazel rules for them as defined in `sample_app/custom_rules.bzl`.
-Custom `Rule` classes must follow the interface in `pazel/bazel_rules.py`.
+The user can define custom Bazel rules by defining a new `Rule` class and by
+adding the class to `EXTRA_RULES` list in `.pazelrc`. `sample_app/.pazelrc` defines a custom
+`PyDoctestRule` class that identifies all doctests and generates custom `py_doctest` Bazel rules for
+them as defined in `sample_app/custom_rules.bzl`. Custom `Rule` classes must follow the interface in
+`pazel/bazel_rules.py`.

--- a/pazel/parse_imports.py
+++ b/pazel/parse_imports.py
@@ -144,3 +144,5 @@ def _in_public_interface(package_path, unknown):
                     for element in node.value.elts:
                         if element.s == unknown:
                             return True
+
+    return False

--- a/pazel/pazel_extensions.py
+++ b/pazel/pazel_extensions.py
@@ -10,6 +10,7 @@ import os
 
 from pazel.bazel_rules import REGISTERED_RULES  # noqa
 from pazel.generate_rule import IMPORT_NAME_TO_PIP_NAME     # noqa
+from pazel.generate_rule import LOCAL_IMPORT_NAME_TO_DEP    # noqa
 
 
 PAZELRC_FILE = '.pazelrc'
@@ -78,8 +79,15 @@ def parse_pazel_extensions(directory):
     # Read user-defined mapping from package import names to pip package names.
     user_defined_pip_import_mapping = getattr(pazelrc, 'EXTRA_IMPORT_NAME_TO_PIP_NAME', dict())
 
-    # Update the mapping. TODO: Remove global.
+    # Update the corresponding mapping. TODO: Remove global.
     global IMPORT_NAME_TO_PIP_NAME
     IMPORT_NAME_TO_PIP_NAME.update(user_defined_pip_import_mapping)
+
+    # Read user-defined mapping from local import names to their Bazel dependencies.
+    user_defined_local_dep_mapping = getattr(pazelrc, 'EXTRA_LOCAL_IMPORT_NAME_TO_DEP', dict())
+
+    # Update the corresponding mapping. TODO: Remove global.
+    global LOCAL_IMPORT_NAME_TO_DEP
+    LOCAL_IMPORT_NAME_TO_DEP.update(user_defined_local_dep_mapping)
 
     return output_extension

--- a/sample_app/.pazelrc
+++ b/sample_app/.pazelrc
@@ -38,7 +38,11 @@ class PyDoctestRule(object):
         return imports_doctest
 
 
+# Add custom Rule classes to this list so that pazel registers them.
 EXTRA_RULES = [PyDoctestRule]
 
-
+# Map import name to pip install name, if they differ.
 EXTRA_IMPORT_NAME_TO_PIP_NAME = {'yaml': 'pyyaml'}
+
+# Map local package import name to its Bazel dependency.
+EXTRA_LOCAL_IMPORT_NAME_TO_DEP = dict()


### PR DESCRIPTION
- Allow defining EXTRA_LOCAL_IMPORT_NAME_TO_DEP dictionary in
.pazelrc that allows mapping local package import names to their
Bazel dependencies
- Update README and improve comments in the sample .pazelrc
- Fix minor inconsistencies