### PR TITLE
Refactor pazel extensions

### DIFF
--- a/pazel/BUILD
+++ b/pazel/BUILD
@@ -61,8 +61,5 @@ py_library(
 py_library(
     name = "pazel_extensions",
     srcs = ["pazel_extensions.py"],
-    deps = [
-        ":bazel_rules",
-        ":generate_rule",
-    ],
+    deps = [],
 )

--- a/pazel/app.py
+++ b/pazel/app.py
@@ -24,13 +24,14 @@ def app(input_path, project_root, contains_pre_installed_packages):
         which BUILD files are generated.
         project_root (str): Imports in the Python files are relative to this path.
         contains_pre_installed_packages (bool): Whether the environment is allowed to contain
-        pre-installed packages or whether only the Python standard library is available.
+            pre-installed packages or whether only the Python standard library is available.
 
     Raises:
         RuntimeError: input_path does is not a directory or a Python file.
     """
     # Parse user-defined extensions to pazel.
-    output_extension = parse_pazel_extensions(project_root)
+    output_extension, custom_bazel_rules, import_name_to_pip_name, local_import_name_to_dep = \
+        parse_pazel_extensions(project_root)
 
     # Handle directories.
     if os.path.isdir(input_path):
@@ -49,7 +50,10 @@ def app(input_path, project_root, contains_pre_installed_packages):
                 # generate a Bazel rule for it.
                 if is_python_file(path) and not is_ignored(path, ignored_rules):
                     new_rule = parse_script_and_generate_rule(path, project_root,
-                                                              contains_pre_installed_packages)
+                                                              contains_pre_installed_packages,
+                                                              custom_bazel_rules,
+                                                              import_name_to_pip_name,
+                                                              local_import_name_to_dep)
 
                     # Add the new rule and a newline between it and any previous rules.
                     if new_rule:
@@ -70,7 +74,10 @@ def app(input_path, project_root, contains_pre_installed_packages):
         # Check that the script is not in the list of ignored rules.
         if not is_ignored(input_path, ignored_rules):
             build_source = parse_script_and_generate_rule(input_path, project_root,
-                                                          contains_pre_installed_packages)
+                                                          contains_pre_installed_packages,
+                                                          custom_bazel_rules,
+                                                          import_name_to_pip_name,
+                                                          local_import_name_to_dep)
 
             output_build_file(build_source, ignored_rules, output_extension, build_file_path)
     else:

--- a/pazel/helpers.py
+++ b/pazel/helpers.py
@@ -35,7 +35,7 @@ def get_build_file_path(path):
 
     Returns
         build_file_path (str): Path to the BUILD in the given directory or in the directory
-        containing the given file.
+            containing the given file.
     """
     if os.path.isdir(path):
         directory = path
@@ -147,8 +147,7 @@ def is_installed(module, some_object=None, contains_pre_installed_packages=False
     Args:
         module (str): Name of a module.
         some_object (str): Name of some object in the module. Can be None.
-        contains_pre_installed_packages (bool): Whether the environment contains external packages
-        or not.
+        contains_pre_installed_packages (bool): Whether the environment contains external packages.
 
     Returns:
         installed (bool): The module is installed in the current environment.

--- a/pazel/parse_build.py
+++ b/pazel/parse_build.py
@@ -15,7 +15,7 @@ def find_existing_rule(build_file_path, script_filename, bazel_rule_type):
 
     Args:
         build_file_path (str): Path to an existing BUILD file that may contain a rule for a given
-        Python script.
+            Python script.
         script_filename (str): File name of the Python script.
         bazel_rule_type (Rule class): pazel-native or a custom class implementing BazelRule.
 
@@ -128,7 +128,7 @@ def get_ignored_rules(build_file_path):
 
     Returns:
         ignored_rules (list of str): Ignored Bazel rule(s). Empty list if no ignored rules were
-        found or if the Bazel BUILD does not exist.
+            found or if the Bazel BUILD does not exist.
     """
     try:
         with open(build_file_path, 'r') as build_file:

--- a/pazel/parse_imports.py
+++ b/pazel/parse_imports.py
@@ -20,7 +20,7 @@ def get_imports(script_source):
     Returns:
         packages (list of tuple): List of (package name, None) tuples.
         from_imports (list of tuple): List of (package/module name, some object) tuples. Note that
-        some object can be a function, object, module, or package.
+            some object can be a function, object, module, or package.
     """
     packages = []
     from_imports = []
@@ -50,8 +50,7 @@ def infer_import_type(all_imports, project_root, contains_pre_installed_packages
     Args:
         all_imports (list of tuple): All imports in a Python script.
         project_root (str): Local imports are assumed to be relative to this path.
-        contains_pre_installed_packages (bool): Whether the environment contains external packages
-        or not.
+        contains_pre_installed_packages (bool): Whether the environment contains external packages.
 
     Returns:
         packages: Set of package names that are imported.

--- a/sample_app/.pazelrc
+++ b/sample_app/.pazelrc
@@ -55,4 +55,4 @@ EXTRA_RULES = [PyDoctestRule]
 EXTRA_IMPORT_NAME_TO_PIP_NAME = {'yaml': 'pyyaml'}
 
 # Map local package import name to its Bazel dependency.
-EXTRA_LOCAL_IMPORT_NAME_TO_DEP = dict()
+EXTRA_LOCAL_IMPORT_NAME_TO_DEP = {'my_dummy_package': '//my_dummy_package'}


### PR DESCRIPTION
- Remove the use of global
- Remove app-wide constants
- Fix style issues
- Informative error messages if variables in .pazelrc are not of the
correct type