### PR TITLE
Support custom import inference rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,15 @@ should define `EXTRA_IMPORT_NAME_TO_PIP_NAME` dictionary accordingly. `sample_ap
 `{'yaml': 'pyyaml'}` as an example. In addition, the user can specify local packages and their
 corresponding Bazel dependencies using the `EXTRA_LOCAL_IMPORT_NAME_TO_DEP` dictionary.
 
-The user can define custom Bazel rules by defining a new class implementing the `BazelRule`
-interface in `pazel/bazel_rules.py` and by adding the class to `EXTRA_RULES` list in `.pazelrc`.
-`sample_app/.pazelrc` defines a custom `PyDoctestRule` class that identifies all doctests and
-generates custom `py_doctest` Bazel rules for them as defined in `sample_app/custom_rules.bzl`.
+The user can add support for custom Bazel rules by defining a new class implementing the `BazelRule`
+interface in `pazel/bazel_rules.py` and by adding that class to `EXTRA_BAZEL_RULES` list in
+`.pazelrc`. `sample_app/.pazelrc` defines a custom `PyDoctestRule` class that identifies all
+doctests and generates custom `py_doctest` Bazel rules for them as defined in
+`sample_app/custom_rules.bzl`.
+
+In addition, the user can implement custom rules for mapping Python imports to Bazel dependencies
+that are not natively supported. That is achieved by defining a new class implementing the
+`InferenceImportRule` interface in `pazel/import_inference_rules.py` and by adding the class to
+`EXTRA_IMPORT_INFERENCE_RULES` list in `.pazelrc`. `sample_app/.pazelrc` defines a custom
+`LocalImportAllInferenceRule` class that generates the correct Bazel dependencies for
+`from X import *` type of imports where `X` is a local package.

--- a/pazel/app.py
+++ b/pazel/app.py
@@ -30,8 +30,8 @@ def app(input_path, project_root, contains_pre_installed_packages):
         RuntimeError: input_path does is not a directory or a Python file.
     """
     # Parse user-defined extensions to pazel.
-    output_extension, custom_bazel_rules, import_name_to_pip_name, local_import_name_to_dep = \
-        parse_pazel_extensions(project_root)
+    output_extension, custom_bazel_rules, custom_import_inference_rules, import_name_to_pip_name, \
+        local_import_name_to_dep = parse_pazel_extensions(project_root)
 
     # Handle directories.
     if os.path.isdir(input_path):
@@ -52,6 +52,7 @@ def app(input_path, project_root, contains_pre_installed_packages):
                     new_rule = parse_script_and_generate_rule(path, project_root,
                                                               contains_pre_installed_packages,
                                                               custom_bazel_rules,
+                                                              custom_import_inference_rules,
                                                               import_name_to_pip_name,
                                                               local_import_name_to_dep)
 
@@ -76,6 +77,7 @@ def app(input_path, project_root, contains_pre_installed_packages):
             build_source = parse_script_and_generate_rule(input_path, project_root,
                                                           contains_pre_installed_packages,
                                                           custom_bazel_rules,
+                                                          custom_import_inference_rules,
                                                           import_name_to_pip_name,
                                                           local_import_name_to_dep)
 

--- a/pazel/bazel_rules.py
+++ b/pazel/bazel_rules.py
@@ -1,4 +1,4 @@
-"""Classes for identifying Bazel rule type of a script and generating rule templates."""
+"""Classes for identifying Bazel rule type of a script and generating new rules to BUILD files."""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -44,7 +44,15 @@ class BazelRule(object):
 
     @staticmethod
     def applies_to(script_name, script_source):
-        """Check whether this rule applies to a given script."""
+        """Check whether this rule applies to a given script.
+
+        Args:
+            script_name (str): Name of a Python script without the .py suffix.
+            script_source (str): Source code of the script.
+
+        Returns:
+            applies (bool): Whether this Bazel rule can be used to represent the script.
+        """
         raise NotImplementedError()
 
     @staticmethod

--- a/pazel/generate_rule.py
+++ b/pazel/generate_rule.py
@@ -105,8 +105,8 @@ def generate_rule(script_path, template, package_names, module_names, data_deps,
 
 
 def parse_script_and_generate_rule(script_path, project_root, contains_pre_installed_packages,
-                                   custom_bazel_rules, import_name_to_pip_name,
-                                   local_import_name_to_dep):
+                                   custom_bazel_rules, custom_import_inference_rules,
+                                   import_name_to_pip_name, local_import_name_to_dep):
     """Generate Bazel Python rule for a Python script.
 
     Args:
@@ -115,6 +115,8 @@ def parse_script_and_generate_rule(script_path, project_root, contains_pre_insta
         contains_pre_installed_packages (bool): Environment contains pre-installed packages (true)
             or only the standard library (false).
         custom_bazel_rules (list of BazelRule classes): Custom rule classes implementing BazelRule.
+        custom_import_inference_rules (list of ImportInferenceRule classes): Custom rule classes
+            implementing ImportInferenceRule.
         import_name_to_pip_name (dict): Mapping from Python package import name to its pip name.
         local_import_name_to_dep (dict): Mapping from local package import name to its Bazel
             dependency.
@@ -131,7 +133,8 @@ def parse_script_and_generate_rule(script_path, project_root, contains_pre_insta
 
     # Infer the import type: Is a package, module, or an object being imported.
     package_names, module_names = infer_import_type(all_imports, project_root,
-                                                    contains_pre_installed_packages)
+                                                    contains_pre_installed_packages,
+                                                    custom_import_inference_rules)
 
     # Infer the Bazel rule type for the script.
     bazel_rule_type = infer_bazel_rule_type(script_path, script_source, custom_bazel_rules)

--- a/pazel/import_inference_rules.py
+++ b/pazel/import_inference_rules.py
@@ -1,0 +1,29 @@
+"""Interface for defining custom classes for inferring import type."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+class ImportInferenceRule(object):
+    """Base class defining the interface for custom import inference classes.
+
+    Custom classes define how a Python import is mapped to Bazel dependencies.
+    """
+
+    @staticmethod
+    def holds(project_root, base, unknown):
+        """If this import inference rule holds, then return imported packages and/or modules.
+
+        Args:
+            project_root (str): Local imports are assumed to be relative to this path.
+            base (str): Name of a package or a module.
+            unknown (str): Can package, module, function or any other object.
+
+        Returns:
+            packages (list of str or None): Imported package names. None if no packages are imported
+                or if the rule does not match the import.
+            modules (list of str or None): Imported module names. None if no modules are imported or
+                if the rule does not match the import.
+        """
+        raise NotImplementedError()

--- a/pazel/parse_imports.py
+++ b/pazel/parse_imports.py
@@ -41,7 +41,7 @@ def get_imports(script_source):
     return packages, from_imports
 
 
-def infer_import_type(all_imports, project_root, contains_pre_installed_packages):
+def infer_import_type(all_imports, project_root, contains_pre_installed_packages, custom_rules):
     """Infer what is being imported.
 
     Given a list of tuples (package/module, some object) infer whether the first element is a
@@ -61,9 +61,6 @@ def infer_import_type(all_imports, project_root, contains_pre_installed_packages
 
     # Base is package/module and the type of unknown is inferred below.
     for base, unknown in all_imports:
-        if unknown == '*':
-            raise NotImplementedError("Importing everything with * is not supported.")
-
         # Early exit if base is in the installed modules of the current environment.
         if is_installed(base, unknown, contains_pre_installed_packages):
             continue
@@ -99,6 +96,28 @@ def infer_import_type(all_imports, project_root, contains_pre_installed_packages
         package_path = os.path.join(project_root, base.replace('.', '/'))
         if os.path.isdir(package_path) and _in_public_interface(package_path, unknown):
             modules.append(base + '.__init__')
+            continue
+
+        # Loop custom inference rules used for parsing imports that pazel does not support.
+        # These custom rules define how a Python import is mapped to Bazel dependencies.
+        custom_rule_matches = False
+
+        for inference_rule in custom_rules:
+            new_packages, new_modules = inference_rule.holds(project_root, base, unknown)
+
+            # If the rule holds, then add to the list of packages and/or modules.
+            if new_packages is not None:
+                packages.extend(new_packages)
+
+            if new_modules is not None:
+                modules.extend(new_modules)
+
+            if new_packages is not None or new_modules is not None:
+                custom_rule_matches = True  # Only allow one match for custom rules.
+                break
+
+        # One custom rule matched, continue to the next import.
+        if custom_rule_matches:
             continue
 
         # Finally, assume that base is either a pip installable or a local package.

--- a/pazel/pazel_extensions.py
+++ b/pazel/pazel_extensions.py
@@ -39,6 +39,8 @@ def parse_pazel_extensions(directory):
     Returns:
         output_extension (OutputExtension): Object containing user-defined header and footer.
         custom_bazel_rules (list of BazelRule classes): Custom BazelRule classes.
+        custom_import_inference_rules (list of ImportInferenceRule classes): Custom classes
+            for inferring import types.
         import_name_to_pip_name (dict): Mapping from Python package import name to its pip name.
         local_import_name_to_dep (dict): Mapping from local package import name to its Bazel
             dependency.
@@ -73,8 +75,13 @@ def parse_pazel_extensions(directory):
     output_extension = OutputExtension(header, footer)
 
     # Read user-defined BazelRule classes.
-    custom_bazel_rules = getattr(pazelrc, 'EXTRA_RULES', [])
-    assert isinstance(custom_bazel_rules, list), "EXTRA_RULES must be a list."
+    custom_bazel_rules = getattr(pazelrc, 'EXTRA_BAZEL_RULES', [])
+    assert isinstance(custom_bazel_rules, list), "EXTRA_BAZEL_RULES must be a list."
+
+    # Read user-defined ImportInferenceRule classes.
+    custom_import_inference_rules = getattr(pazelrc, 'EXTRA_IMPORT_INFERENCE_RULES', [])
+    assert isinstance(custom_import_inference_rules, list), \
+        "EXTRA_IMPORT_INFERENCE_RULES must be a list."
 
     # Read user-defined mapping from package import names to pip package names.
     import_name_to_pip_name = getattr(pazelrc, 'EXTRA_IMPORT_NAME_TO_PIP_NAME', dict())
@@ -86,4 +93,5 @@ def parse_pazel_extensions(directory):
     assert isinstance(local_import_name_to_dep, dict), \
         "EXTRA_LOCAL_IMPORT_NAME_TO_DEP must be a dictionary."
 
-    return output_extension, custom_bazel_rules, import_name_to_pip_name, local_import_name_to_dep
+    return output_extension, custom_bazel_rules, custom_import_inference_rules, \
+        import_name_to_pip_name, local_import_name_to_dep

--- a/sample_app/.pazelrc
+++ b/sample_app/.pazelrc
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os
 import re
 
 from pazel.bazel_rules import BazelRule
@@ -48,8 +49,50 @@ class PyDoctestRule(BazelRule):
         return imports_doctest
 
 
-# Add custom Rule classes to this list so that pazel registers them.
-EXTRA_RULES = [PyDoctestRule]
+class LocalImportAllInferenceRule(object):
+    """Import inference rule for "from some_local_package import *" type of imports.
+
+    The rule is not recursive so only modules in the first level will be imported.
+    """
+
+    @staticmethod
+    def holds(project_root, base, unknown):
+        """Check if base is a local package and unknown is '*'.
+
+        Args:
+            project_root (str): Local imports are assumed to be relative to this path.
+            base (str): Name of a package or a module.
+            unknown (str): Can package, module, function or any other object.
+
+        Returns:
+            packages (None): The rule applies only to modules.
+            modules (list of str or None): The imported modules. None if the rule does not match.
+        """
+        packages = None
+        modules = None
+
+        # Check if 'base' is a local package.
+        package_path = os.path.join(project_root, base.replace('.', '/'))
+        base_is_package = os.path.isdir(package_path)
+
+        if base_is_package and unknown == '*':
+            python_filenames = [f.replace('.py', '') for f in os.listdir(package_path)
+                                if f.endswith('.py')]
+
+            modules = []
+
+            for python_filename in python_filenames:
+                dotted_path = base + '.%s' % python_filename
+                modules.append(dotted_path)
+
+        return packages, modules
+
+
+# Add custom classes implementing BazelRule to this list so that pazel registers them.
+EXTRA_BAZEL_RULES = [PyDoctestRule]
+
+# Add custom import inference classes implementing ImportInferenceRule to this list.
+EXTRA_IMPORT_INFERENCE_RULES = [LocalImportAllInferenceRule]
 
 # Map import name to pip install name, if they differ.
 EXTRA_IMPORT_NAME_TO_PIP_NAME = {'yaml': 'pyyaml'}

--- a/sample_app/foo/BUILD
+++ b/sample_app/foo/BUILD
@@ -31,6 +31,12 @@ py_binary(
     deps = [],
 )
 
+py_library(
+    name = "bar6",
+    srcs = ["bar6.py"],
+    deps = ["//xyz:abc1"],
+)
+
 # pazel-ignore
 py_test(    # pazel would mark bar4.py as a library but it remains as a test because it is ignored.
     name = "bar4",

--- a/sample_app/foo/bar6.py
+++ b/sample_app/foo/bar6.py
@@ -1,0 +1,1 @@
+from xyz import *


### PR DESCRIPTION
- Allow defining custom import inference rules in .pazelrc
- Allows extending pazel so that the correct Bazelvdependencies
are added for Python imports that are not natively supported
- Add example to sample_app that generates all dependencies for
"from X import *" type of imports where X is a local package
- Update README