### PR TITLE
'load' statement for custom Bazel rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Use `pazel -r <some_path>` to override the path to which the imports are relativ
 By default, `pazel` adds rules to install all external Python packages. If your environment has
 pre-installed packages for which these rules are not required, then use `pazel -p`.
 
+`pazel` config file `.pazelrc` is read from the current working directory. Use
+`pazel -c <pazelrc_path>` to specify an alternative path.
 
 ### Ignoring rules in existing BUILD files
 

--- a/pazel/bazel_rules.py
+++ b/pazel/bazel_rules.py
@@ -72,6 +72,11 @@ class BazelRule(object):
 
         return match
 
+    @staticmethod
+    def get_load_statement():
+        """If the rule requires a special 'load' statement, return it, otherwise return None."""
+        return None
+
 
 class PyBinaryRule(BazelRule):
     """Class for representing Bazel-native py_binary."""
@@ -175,7 +180,7 @@ def infer_bazel_rule_type(script_path, script_source, custom_rules):
         custom_rules (list of BazelRule classes): User-defined classes implementing BazelRule.
 
     Returns:
-        bazel_rule_type (BaseRule): Rule object representing the type of the Python script.
+        bazel_rule_type (BazelRule): Rule object representing the type of the Python script.
 
     Raises:
         RuntimeError: If zero or more than one Bazel rule is found for the current script.

--- a/sample_app/.pazelrc
+++ b/sample_app/.pazelrc
@@ -48,6 +48,11 @@ class PyDoctestRule(BazelRule):
 
         return imports_doctest
 
+    @staticmethod
+    def get_load_statement():
+        """Return the load statement required for using this rule."""
+        return 'load("//:custom_rules.bzl", "py_doctest")'
+
 
 class LocalImportAllInferenceRule(object):
     """Import inference rule for "from some_local_package import *" type of imports.
@@ -99,3 +104,7 @@ EXTRA_IMPORT_NAME_TO_PIP_NAME = {'yaml': 'pyyaml'}
 
 # Map local package import name to its Bazel dependency.
 EXTRA_LOCAL_IMPORT_NAME_TO_DEP = {'my_dummy_package': '//my_dummy_package'}
+
+# Change 'REQUIREMENT' to override the default load statement of the Bazel rule for
+# installing pip packages. See https://github.com/bazelbuild/rules_python
+REQUIREMENT = """load("@my_deps//:requirements.bzl", "requirement")"""

--- a/sample_app/tests/BUILD
+++ b/sample_app/tests/BUILD
@@ -1,7 +1,5 @@
 package(default_visibility = ["//visibility:public"])
 load("@my_deps//:requirements.bzl", "requirement")
-
-# pazel-ignore
 load("//:custom_rules.bzl", "py_doctest")
 
 py_library(


### PR DESCRIPTION
- Custom Bazel rules define a load statement that is added to BUILD
files if the custom rule is used
- Add command line flag for specifying path to .pazelrc
- Bug fixes
- Option to override the 'requirement' 'load' statement