### PR TITLE
'load' statement for custom Bazel rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Use `pazel -r <some_path>` to override the path to which the imports are relativ
 By default, `pazel` adds rules to install all external Python packages. If your environment has
 pre-installed packages for which these rules are not required, then use `pazel -p`.
 
+`pazel` config file `.pazelrc` is read from the current working directory. Use
+`pazel -c <pazelrc_path>` to specify an alternative path.
 
 ### Ignoring rules in existing BUILD files
 

--- a/pazel/bazel_rules.py
+++ b/pazel/bazel_rules.py
@@ -72,6 +72,11 @@ class BazelRule(object):
 
         return match
 
+    @staticmethod
+    def get_load_statement():
+        """If the rule requires a special 'load' statement, return it, otherwise return None."""
+        return None
+
 
 class PyBinaryRule(BazelRule):
     """Class for representing Bazel-native py_binary."""
@@ -175,7 +180,7 @@ def infer_bazel_rule_type(script_path, script_source, custom_rules):
         custom_rules (list of BazelRule classes): User-defined classes implementing BazelRule.
 
     Returns:
-        bazel_rule_type (BaseRule): Rule object representing the type of the Python script.
+        bazel_rule_type (BazelRule): Rule object representing the type of the Python script.
 
     Raises:
         RuntimeError: If zero or more than one Bazel rule is found for the current script.

--- a/pazel/output_build.py
+++ b/pazel/output_build.py
@@ -5,42 +5,63 @@ from __future__ import division
 from __future__ import print_function
 
 
-# Used for installing pip packages. See https://github.com/bazelbuild/rules_python
-REQUIREMENT = """load("@my_deps//:requirements.bzl", "requirement")"""
-
-
 def _append_newline(source):
     """Add newline to a string if it does not end with a newline."""
     return source if source.endswith('\n') else source + '\n'
 
 
-def output_build_file(build_source, ignored_rules, output_extension, build_file_path):
+def output_build_file(build_source, ignored_rules, output_extension, custom_bazel_rules,
+                      build_file_path, requirement_load):
     """Output a BUILD file.
 
     Args:
         build_source (str): The contents of the BUILD file to output.
         ignored_rules (list of str): Rules the user wants to keep as is.
         output_extension (OutputExtension): User-defined header and footer.
+        custom_bazel_rules (list of BazelRule classes): User-defined BazelRule classes.
         build_file_path (str): Path to the BUILD file in which build_source is written.
+        requirement_load (str): Statement for loading the 'requirement' rule.
     """
     header = ''
 
     if output_extension.header:
         header += _append_newline(output_extension.header)
 
-    # If the BUILD file contains external packages, add the Bazel method for installing them.
-    if 'requirement("' in build_source:
-        header += _append_newline(REQUIREMENT)
-
-    # Add ignored load statements right after the header.
+    # Categorize ignored rules to 'load' statements and other remaining rules.
+    ignored_load_statements = []
     remaining_ignored_rules = []
 
     if ignored_rules:
         for ignored_rule in ignored_rules:
             if 'load(' in ignored_rule:
-                header += _append_newline(ignored_rule)
+                ignored_load_statements.append(ignored_rule)
             else:
                 remaining_ignored_rules.append(ignored_rule)
+
+    # If the BUILD file contains external packages, add the 'load' statement for installing them.
+    # Check that this statement is not in the ignored 'load' statements.
+    ignored_source = '\n'.join(remaining_ignored_rules)
+
+    if any(['requirement("' in source for source in (build_source, ignored_source)]):
+        in_ignored_load_statements = any(['requirement("' in statement for statement in
+                                          ignored_load_statements])
+
+        if not in_ignored_load_statements:
+            header += _append_newline(requirement_load)
+
+    # If the BUILD source contains custom Bazel rules, then add the load statements for them unless
+    # the load statements are already in the ignored load statements.
+    for custom_rule in custom_bazel_rules:
+        rule_identifier = custom_rule.rule_identifier
+        in_ignored_load_statements = any([rule_identifier in statement for statement in
+                                          ignored_load_statements])
+
+        if rule_identifier in build_source and not in_ignored_load_statements:
+            header += _append_newline(custom_rule.get_load_statement())
+
+    # Add ignored load statements right after the header.
+    for ignored_load in ignored_load_statements:
+        header += _append_newline(ignored_load)
 
     # If a header exists, add a newline between it and the rules.
     if header:

--- a/sample_app/.pazelrc
+++ b/sample_app/.pazelrc
@@ -48,6 +48,11 @@ class PyDoctestRule(BazelRule):
 
         return imports_doctest
 
+    @staticmethod
+    def get_load_statement():
+        """Return the load statement required for using this rule."""
+        return 'load("//:custom_rules.bzl", "py_doctest")'
+
 
 class LocalImportAllInferenceRule(object):
     """Import inference rule for "from some_local_package import *" type of imports.
@@ -99,3 +104,7 @@ EXTRA_IMPORT_NAME_TO_PIP_NAME = {'yaml': 'pyyaml'}
 
 # Map local package import name to its Bazel dependency.
 EXTRA_LOCAL_IMPORT_NAME_TO_DEP = {'my_dummy_package': '//my_dummy_package'}
+
+# Change 'REQUIREMENT' to override the default load statement of the Bazel rule for
+# installing pip packages. See https://github.com/bazelbuild/rules_python
+REQUIREMENT = """load("@my_deps//:requirements.bzl", "requirement")"""

--- a/sample_app/tests/BUILD
+++ b/sample_app/tests/BUILD
@@ -1,7 +1,5 @@
 package(default_visibility = ["//visibility:public"])
 load("@my_deps//:requirements.bzl", "requirement")
-
-# pazel-ignore
 load("//:custom_rules.bzl", "py_doctest")
 
 py_library(


### PR DESCRIPTION
- Custom Bazel rules define a load statement that is added to BUILD
files if the custom rule is used
- Add command line flag for specifying path to .pazelrc
- Bug fixes
- Option to override the 'requirement' 'load' statement