### PR TITLE
Make pazel more compatible with buildifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,10 @@ that are not natively supported. That is achieved by defining a new class implem
 `EXTRA_IMPORT_INFERENCE_RULES` list in `.pazelrc`. `sample_app/.pazelrc` defines a custom
 `LocalImportAllInferenceRule` class that generates the correct Bazel dependencies for
 `from X import *` type of imports where `X` is a local package.
+
+
+## BUILD file formatting
+
+`pazel` generates BUILD files that are nearly compatible with
+[Buildifier](https://github.com/bazelbuild/buildtools/tree/master/buildifier). Buildifier can be
+applied on `pazel`-generated BUILD files to remove the remaining differences, if needed.

--- a/pazel/bazel_rules.py
+++ b/pazel/bazel_rules.py
@@ -8,26 +8,27 @@ import os
 import re
 
 # These templates will be filled and used to generate BUILD files.
+# Note that both 'data' and 'deps' can be empty in which case they are left out from the rules.
 PY_BINARY_TEMPLATE = """py_binary(
     name = "{name}",
     srcs = ["{name}.py"],
-    deps = [{deps}],
     {data}
+    {deps}
 )"""
 
 PY_LIBRARY_TEMPLATE = """py_library(
     name = "{name}",
     srcs = ["{name}.py"],
-    deps = [{deps}],
     {data}
+    {deps}
 )"""
 
 PY_TEST_TEMPLATE = """py_test(
     name = "{name}",
     srcs = ["{name}.py"],
     size = "{size}",
-    deps = [{deps}],
     {data}
+    {deps}
 )"""
 
 

--- a/pazel/output_build.py
+++ b/pazel/output_build.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import re
+
 
 def _append_newline(source):
     """Add newline to a string if it does not end with a newline."""
@@ -80,4 +82,8 @@ def output_build_file(build_source, ignored_rules, output_extension, custom_baze
 
     with open(build_file_path, 'w') as build_file:
         output = _append_newline(output)
+
+        # Remove possible duplicate newlines (the user may have added such accidentally).
+        output = re.sub('\n\n\n*', '\n\n', output)
+
         build_file.write(output)

--- a/pazel/tests/BUILD
+++ b/pazel/tests/BUILD
@@ -7,6 +7,13 @@ py_library(
 )
 
 py_test(
+    name = "test_generate_rule",
+    srcs = ["test_generate_rule.py"],
+    size = "small",
+    deps = ["//pazel:generate_rule"],
+)
+
+py_test(
     name = "test_helpers",
     srcs = ["test_helpers.py"],
     size = "small",

--- a/pazel/tests/test_generate_rule.py
+++ b/pazel/tests/test_generate_rule.py
@@ -1,0 +1,27 @@
+"""Test generating Bazel rules."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+
+from pazel.generate_rule import sort_module_names
+
+
+class TestGenerateRule(unittest.TestCase):
+    """Test generating Bazel rules."""
+
+    def test_sort_module_names(self):
+        """Test sort_module_names."""
+        modules = ["abc", "xyz", "foo.bar1", "foo.bar2", "foo.abc.abc", "foo.cba.cba"]
+        sorted_modules = sort_module_names(modules)
+
+        expected_sorted_modules = ["abc", "xyz", "foo.bar1", "foo.bar2", "foo.abc.abc",
+                                   "foo.cba.cba"]
+
+        self.assertEqual(sorted_modules, expected_sorted_modules)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sample_app/.pazelrc
+++ b/sample_app/.pazelrc
@@ -10,7 +10,9 @@ import re
 from pazel.bazel_rules import BazelRule
 
 
-HEADER = """package(default_visibility = ["//visibility:public"])"""
+HEADER = """package(default_visibility = ["//visibility:public"])
+
+"""
 
 FOOTER = """# My footer"""
 

--- a/sample_app/BUILD
+++ b/sample_app/BUILD
@@ -3,7 +3,6 @@ package(default_visibility = ["//visibility:public"])
 py_library(
     name = "__init__",
     srcs = ["__init__.py"],
-    deps = [],
 )
 
 # My footer

--- a/sample_app/foo/BUILD
+++ b/sample_app/foo/BUILD
@@ -1,4 +1,5 @@
 package(default_visibility = ["//visibility:public"])
+
 load("@my_deps//:requirements.bzl", "requirement")
 
 # pazel-ignore
@@ -28,13 +29,17 @@ py_library(
 py_binary(
     name = "bar3",
     srcs = ["bar3.py"],
-    deps = [],
 )
 
 py_library(
     name = "bar6",
     srcs = ["bar6.py"],
     deps = ["//xyz:abc1"],
+)
+
+py_library(
+    name = "foo",
+    srcs = ["foo.py"],
 )
 
 # pazel-ignore

--- a/sample_app/foo/foo.py
+++ b/sample_app/foo/foo.py
@@ -1,0 +1,1 @@
+# Dummy file to showcase pazel formatting.

--- a/sample_app/tests/BUILD
+++ b/sample_app/tests/BUILD
@@ -1,22 +1,22 @@
 package(default_visibility = ["//visibility:public"])
+
 load("@my_deps//:requirements.bzl", "requirement")
 load("//:custom_rules.bzl", "py_doctest")
 
 py_library(
     name = "__init__",
     srcs = ["__init__.py"],
-    deps = [],
 )
 
 py_test(
     name = "test_bar1",
     srcs = ["test_bar1.py"],
     size = "medium",
+    data = ["test_data/dummy"],
     deps = [
         "//foo:bar1",
         requirement("requests"),
     ],
-    data = ["test_data/dummy"]
 )
 
 py_test(
@@ -30,8 +30,7 @@ py_test(
     name = "test_bar3",
     srcs = ["test_bar3.py"],
     size = "small",
-    deps = [],
-    data = glob(["test_data/*.png"])
+    data = glob(["test_data/*.png"]),
 )
 
 py_doctest(

--- a/sample_app/xyz/BUILD
+++ b/sample_app/xyz/BUILD
@@ -3,7 +3,10 @@ package(default_visibility = ["//visibility:public"])
 py_binary(
     name = "abc1",
     srcs = ["abc1.py"],
-    deps = ["//foo:__init__"],
+    deps = [
+        "//foo:__init__",
+        "//foo:foo",
+    ],
 )
 
 # My footer

--- a/sample_app/xyz/abc1.py
+++ b/sample_app/xyz/abc1.py
@@ -1,4 +1,5 @@
 from foo import sample  # Import from foo's public interface.
+from foo import foo     # Import a module with the same name as the package.
 
 
 def main():


### PR DESCRIPTION
- Change the order of keyword arguments in the generated rules
- Change the order of dependencies
- Make 'data' and 'deps' disappear if a file does not have dependencies
- Filter duplicate newlines