### PR TITLE
Fix « The native git_repository rule is deprecated » error

### DIFF
--- a/sample_app/WORKSPACE
+++ b/sample_app/WORKSPACE
@@ -1,5 +1,7 @@
 workspace(name = "sample_app")
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
 git_repository(
     name = "io_bazel_rules_python",
     remote = "https://github.com/bazelbuild/rules_python.git",


### PR DESCRIPTION
Fix « ERROR: error loading package '': Encountered error while reading extension file 'python/pip.bzl': no such package '@io_bazel_rules_python//python': The native git_repository rule is deprecated. load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository") for a replacement. » error