### PR TITLE
Provide an option to generate BUILD.bazel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+# Ignore all bazel symlinks
+/bazel-*

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ pre-installed packages for which these rules are not required, then use `pazel -
 ### Ignoring rules in existing BUILD files
 
 The tag `# pazel-ignore` causes `pazel` to ignore the rule that immediately follows the tag in an
-existing BUILD file. In particular, the tag can be used to skip custom rules that `pazel` does not 
+existing BUILD file. In particular, the tag can be used to skip custom rules that `pazel` does not
 handle. `pazel` places the ignored rules at the bottom of the BUILD file. See `sample_app/foo/BUILD`
 for an example using the tag.
 
@@ -89,6 +89,9 @@ working directory or provided explicitly with `pazel -c <pazelrc_path>`.
 The user can define variables `HEADER` and `FOOTER` to add custom header and footer to
 all BUILD files, respectively. See `sample_app/.pazelrc` and `sample_app/BUILD` for an example that
 adds the same `visibility` to all BUILD files.
+
+If you'd like to generate BUILD.bazel files, you can set the option:
+`BUILD_FILE_NAME = 'BUILD.bazel'`.
 
 If some pip package has different install name than import name, then the user
 should define `EXTRA_IMPORT_NAME_TO_PIP_NAME` dictionary accordingly. `sample_app/.pazelrc` has

--- a/pazel/app.py
+++ b/pazel/app.py
@@ -32,7 +32,7 @@ def app(input_path, project_root, contains_pre_installed_packages, pazelrc_path)
     """
     # Parse user-defined extensions to pazel.
     output_extension, custom_bazel_rules, custom_import_inference_rules, import_name_to_pip_name, \
-        local_import_name_to_dep, requirement_load = parse_pazel_extensions(pazelrc_path)
+        local_import_name_to_dep, requirement_load, build_file_name = parse_pazel_extensions(pazelrc_path)
 
     # Handle directories.
     if os.path.isdir(input_path):
@@ -41,7 +41,7 @@ def app(input_path, project_root, contains_pre_installed_packages, pazelrc_path)
             build_source = ''
 
             # Parse ignored rules in an existing BUILD file, if any.
-            build_file_path = get_build_file_path(dirpath)
+            build_file_path = get_build_file_path(dirpath, build_file_name)
             ignored_rules = get_ignored_rules(build_file_path)
 
             for filename in sorted(filenames):

--- a/pazel/helpers.py
+++ b/pazel/helpers.py
@@ -40,9 +40,9 @@ def get_build_file_path(path):
     if os.path.isdir(path):
         directory = path
     else:
-        directory = os.path.dirpath(path)
+        directory = os.path.dirname(path)
 
-    build_file_path = os.path.join(directory, 'BUILD')
+    build_file_path = os.path.join(directory, 'BUILD.bazel')
 
     return build_file_path
 

--- a/pazel/helpers.py
+++ b/pazel/helpers.py
@@ -27,7 +27,7 @@ def contains_python_file(directory):
     return contains_py
 
 
-def get_build_file_path(path):
+def get_build_file_path(path, build_file_name):
     """Get path to a BUILD file next to a given path.
 
     Args:
@@ -42,7 +42,7 @@ def get_build_file_path(path):
     else:
         directory = os.path.dirname(path)
 
-    build_file_path = os.path.join(directory, 'BUILD.bazel')
+    build_file_path = os.path.join(directory, build_file_name)
 
     return build_file_path
 

--- a/pazel/pazel_extensions.py
+++ b/pazel/pazel_extensions.py
@@ -92,5 +92,10 @@ def parse_pazel_extensions(pazelrc_path):
 
     assert isinstance(requirement_load, str), "REQUIREMENT must be a string."
 
+    default_build_file_name = 'BUILD'
+    build_file_name = getattr(pazelrc, 'BUILD_FILE_NAME', default_build_file_name)
+    assert isinstance(build_file_name, str), "BUILD_FILE_NAME must be a string."
+
     return output_extension, custom_bazel_rules, custom_import_inference_rules, \
-        import_name_to_pip_name, local_import_name_to_dep, requirement_load
+        import_name_to_pip_name, local_import_name_to_dep, requirement_load, \
+        build_file_name

--- a/pazel/tests/test_pazel_extensions.py
+++ b/pazel/tests/test_pazel_extensions.py
@@ -17,7 +17,8 @@ class TestParseImports(unittest.TestCase):
         pazelrc_path = 'fail'
 
         output_extension, custom_bazel_rules, custom_import_inference_rules, \
-            import_name_to_pip_name, local_import_name_to_dep, requirement_load \
+            import_name_to_pip_name, local_import_name_to_dep, requirement_load, \
+                build_file_name \
             = parse_pazel_extensions(pazelrc_path)
 
         self.assertEqual(output_extension.header, '')


### PR DESCRIPTION
In my project, I already have files name build, so I'd like to generate BUILD.bazel files via pazel. This PR adds a new option:
`BUILD_FILE_NAME = 'BUILD.bazel'`
and setting that allows all the generated files to be named as BUILD.bazel instead of the default BUILD.

Bonus: update gitignore to ignore all bazel-* symlinks

This PR fixes #21 

Testing Done:
```
❯ bazel test //pazel/...
INFO: Analyzed 15 targets (0 packages loaded, 0 targets configured).
INFO: Found 10 targets and 5 test targets...
INFO: Elapsed time: 0.210s, Critical Path: 0.01s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
//pazel/tests:test_bazel_rules                                  (cached) PASSED in 0.4s
//pazel/tests:test_generate_rule                                (cached) PASSED in 0.1s
//pazel/tests:test_helpers                                      (cached) PASSED in 0.1s
//pazel/tests:test_parse_imports                                (cached) PASSED in 0.1s
//pazel/tests:test_pazel_extensions                             (cached) PASSED in 0.1s

INFO: Build completed successfully, 1 total action
```
