### PR TITLE
Allow multiple rules per file

### DIFF
--- a/pazel/app.py
+++ b/pazel/app.py
@@ -62,7 +62,8 @@ def app(input_path, project_root, contains_pre_installed_packages, pazelrc_path)
                         if build_source:
                             build_source += 2*'\n'
 
-                        build_source += new_rule
+                        for rule in new_rule:
+                            build_source += rule + 2*'\n'
 
             # If Python files were found, output the BUILD file.
             if build_source != '' or ignored_rules:

--- a/pazel/app.py
+++ b/pazel/app.py
@@ -22,6 +22,7 @@ def extract_transitive_dependencies(package_name, deps):
     else:
         for p in deps:
             package_name = p.get('package_name')
+            yield package_name
             deps = p.get('dependencies')
             for d in extract_transitive_dependencies(package_name, deps):
                 yield d
@@ -46,7 +47,7 @@ def flatten_dict(data):
             for d1 in flatten_dict(d['dependencies']):
                 yield d1
 
-def app(input_path, project_root, contains_pre_installed_packages, pazelrc_path, pipfile, ignore_dir):
+def app(input_path, project_root, contains_pre_installed_packages, pazelrc_path, pipfile):
     """Generate BUILD file(s) for a Python script or a directory of Python scripts.
 
     Args:
@@ -74,12 +75,12 @@ def app(input_path, project_root, contains_pre_installed_packages, pazelrc_path,
 
             # Parse ignored rules in an existing BUILD file, if any.
             build_file_path = get_build_file_path(dirpath)
+            if os.path.exists(build_file_path):
+                continue
             ignored_rules = get_ignored_rules(build_file_path)
 
             for filename in sorted(filenames):
                 path = os.path.join(dirpath, filename)
-                if any(ignore_path in path for ignore_path in ignore_dir.split(',')):
-                    continue
 
                 # If a Python file is met and it is not in the list of ignored rules,
                 # generate a Bazel rule for it.
@@ -162,7 +163,7 @@ def main():
     if custom_pazelrc_path:
         assert os.path.isfile(args.pazelrc), ".pazelrc file %s not found." % args.pazelrc
 
-    app(args.input_path, args.project_root, args.pre_installed_packages, args.pazelrc, args.pipfile, args.ignore_dir)
+    app(args.input_path, args.project_root, args.pre_installed_packages, args.pazelrc, args.pipfile)
     print('Generated BUILD files for %s.' % args.input_path)
 
 

--- a/pazel/app.py
+++ b/pazel/app.py
@@ -12,40 +12,11 @@ from pazel.generate_rule import parse_script_and_generate_rule
 from pazel.helpers import get_build_file_path
 from pazel.helpers import is_ignored
 from pazel.helpers import is_python_file
+from pazel.helpers import extract_dependencies
 from pazel.output_build import output_build_file
 from pazel.parse_build import get_ignored_rules
 from pazel.pazel_extensions import parse_pazel_extensions
 
-def extract_transitive_dependencies(package_name, deps):
-    if not deps:
-        yield package_name
-    else:
-        for p in deps:
-            package_name = p.get('package_name')
-            yield package_name
-            deps = p.get('dependencies')
-            for d in extract_transitive_dependencies(package_name, deps):
-                yield d
-
-def extract_dependencies(data):
-    packages = {}
-    for d in flatten_dict(data):
-        package_name = d.get('key')
-        deps = d.get('dependencies')
-        all_deps = list(extract_transitive_dependencies(package_name, deps))
-        # add original package_name
-        all_deps.append(package_name)
-        packages[package_name] = all_deps
-    return packages
-
-def flatten_dict(data):
-    for d in data:
-        yield d
-        if d['dependencies'] == []:
-            yield d
-        else:
-            for d1 in flatten_dict(d['dependencies']):
-                yield d1
 
 def app(input_path, project_root, contains_pre_installed_packages, pazelrc_path, pipfile):
     """Generate BUILD file(s) for a Python script or a directory of Python scripts.
@@ -152,8 +123,6 @@ def main():
                         help='Path to .pazelrc file.')
     parser.add_argument('-f', '--pipfile', type=str, default=pipfile,
                         help='Path to Pipfile.lock.json file.')
-    parser.add_argument('-i', '--ignore_dir', type=str,
-                        help='comma seprated list of patterns to ignore')
 
     args = parser.parse_args()
 

--- a/pazel/bazel_rules.py
+++ b/pazel/bazel_rules.py
@@ -199,7 +199,8 @@ def infer_bazel_rule_type(script_path, script_source, custom_rules):
 
     if not bazel_rule_types:
         raise RuntimeError("No suitable Bazel rule type found for %s." % script_path)
-    elif len(bazel_rule_types) > 1:
+    return bazel_rule_types
+    if len(bazel_rule_types) > 1:
         # If the script is recognized by pazel native rule(s) and one exactly custom rule, then use
         # the custom rule. This is because the pazel native rules may generate false positives.
         is_custom = [rule not in native_rules for rule in bazel_rule_types]

--- a/pazel/generate_rule.py
+++ b/pazel/generate_rule.py
@@ -202,15 +202,18 @@ def parse_script_and_generate_rule(script_path, project_root, contains_pre_insta
                                                     custom_import_inference_rules)
 
     # Infer the Bazel rule type for the script.
-    bazel_rule_type = infer_bazel_rule_type(script_path, script_source, custom_bazel_rules)
+    rules = []
+    bazel_rule_types = infer_bazel_rule_type(script_path, script_source, custom_bazel_rules)
+    for bazel_rule_type in bazel_rule_types:
 
-    # Data dependencies or test size cannot be inferred from the script source code currently.
-    # Use information in any existing BUILD files.
-    data_deps = find_existing_data_deps(script_path, bazel_rule_type)
-    test_size = find_existing_test_size(script_path, bazel_rule_type)
+        # Data dependencies or test size cannot be inferred from the script source code currently.
+        # Use information in any existing BUILD files.
+        data_deps = find_existing_data_deps(script_path, bazel_rule_type)
+        test_size = find_existing_test_size(script_path, bazel_rule_type)
 
-    # Generate the Bazel Python rule based on the gathered information.
-    rule = generate_rule(script_path, bazel_rule_type.template, package_names, module_names,
-                         data_deps, test_size, import_name_to_pip_name, local_import_name_to_dep)
+        # Generate the Bazel Python rule based on the gathered information.
+        rule = generate_rule(script_path, bazel_rule_type.template, package_names, module_names,
+                             data_deps, test_size, import_name_to_pip_name, local_import_name_to_dep)
+        rules.append(rule)
 
-    return rule
+    return rules

--- a/pazel/helpers.py
+++ b/pazel/helpers.py
@@ -124,6 +124,8 @@ def _is_in_stdlib(module, some_object):
             if 'site-packages' not in path:
                 sys.path.append(path)
 
+    if 'csv' in str(module):
+        return True
     in_stdlib = False
 
     try:

--- a/pazel/helpers.py
+++ b/pazel/helpers.py
@@ -215,3 +215,14 @@ def parse_enclosed_expression(source, start, opening_token):
     expression = source[start:end]
 
     return expression
+
+
+def extract_dependencies(data):
+    packages = {}
+    for d in data:
+        package_name = d.get('package').get("package_name")
+        all_deps = [n.get("package_name") for n in d.get('dependencies')]
+        # add original package_name
+        all_deps.append(package_name)
+        packages[package_name] = all_deps
+    return packages

--- a/pazel/parse_imports.py
+++ b/pazel/parse_imports.py
@@ -70,7 +70,6 @@ def infer_import_type(all_imports, project_root, contains_pre_installed_packages
         custom_rule_matches = False
         for inference_rule in custom_rules:
             new_packages, new_modules = inference_rule.holds(project_root, base, unknown)
-
             # If the rule holds, then add to the list of packages and/or modules.
             if new_packages is not None:
                 packages.extend(new_packages)

--- a/pazel/parse_imports.py
+++ b/pazel/parse_imports.py
@@ -62,13 +62,12 @@ def infer_import_type(all_imports, project_root, contains_pre_installed_packages
     # Base is package/module and the type of unknown is inferred below.
     for base, unknown in all_imports:
         # Early exit if base is in the installed modules of the current environment.
-        if is_installed(base, unknown, contains_pre_installed_packages):
+        if is_installed(base, unknown, contains_pre_installed_packages) and not base.startswith('benchsci'):
             continue
 
         # Prioritize custom inference rules used for parsing imports that pazel does not support.
         # These custom rules define how a Python import is mapped to Bazel dependencies.
         custom_rule_matches = False
-
         for inference_rule in custom_rules:
             new_packages, new_modules = inference_rule.holds(project_root, base, unknown)
 

--- a/pazel/tests/BUILD
+++ b/pazel/tests/BUILD
@@ -25,6 +25,7 @@ py_test(
     srcs = ["test_helpers.py"],
     size = "small",
     deps = ["//pazel:helpers"],
+    data = ["//pazel/tests:Pipfile.lock.json"]
 )
 
 py_test(

--- a/pazel/tests/test_bazel_rules.py
+++ b/pazel/tests/test_bazel_rules.py
@@ -221,13 +221,13 @@ class TestBazelRuleInference(unittest.TestCase):
         custom_rules = []
 
         self.assertEqual(infer_bazel_rule_type(script_name, binary_with_main_source, custom_rules),
-                         PyBinaryRule)
+                         [PyBinaryRule])
         self.assertEqual(infer_bazel_rule_type(script_name, binary_without_main_source,
-                                               custom_rules), PyBinaryRule)
+                                               custom_rules), [PyBinaryRule])
         self.assertEqual(infer_bazel_rule_type(script_name, module_source, custom_rules),
-                         PyLibraryRule)
+                         [PyLibraryRule])
         self.assertEqual(infer_bazel_rule_type(test_script_name, test_source, custom_rules),
-                         PyTestRule)
+                         [PyTestRule])
 
 
 if __name__ == '__main__':

--- a/pazel/tests/test_helpers.py
+++ b/pazel/tests/test_helpers.py
@@ -5,8 +5,10 @@ from __future__ import division
 from __future__ import print_function
 
 import unittest
+from pathlib import Path
+import json
 
-from pazel.helpers import parse_enclosed_expression
+from pazel.helpers import parse_enclosed_expression, extract_dependencies
 
 
 class TestHelpers(unittest.TestCase):
@@ -37,6 +39,10 @@ class TestHelpers(unittest.TestCase):
         expression = parse_enclosed_expression(source, start, '(')
 
         self.assertEqual(expression, expected_expression)
+    def test_extranct_dependencies(self):
+        data = json.load(open(Path(Path(__file__).parent, "Pipfile.lock.json")))
+        data = extract_dependencies(data)
+        assert "packaging" in data["pytest"]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Allow multiple rules per file
* skip project packages/module as installed when working in environment where all the dependencies are installed e.g in a docker image. 
