### PR TITLE
Normalize relative imports into absolute imports.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.pyc
+bazel-bin
+bazel-out
+bazel-pazel
+bazel-testlogs

--- a/pazel/generate_rule.py
+++ b/pazel/generate_rule.py
@@ -193,7 +193,8 @@ def parse_script_and_generate_rule(script_path, project_root, contains_pre_insta
         script_source = script_file.read()
 
     # Get all imports in the script.
-    package_names, from_imports = get_imports(script_source)
+    script_package = script_path.lstrip(project_root).rstrip(".py").replace('/', '.')
+    package_names, from_imports = get_imports(script_source, script_package)
     all_imports = package_names + from_imports
 
     # Infer the import type: Is a package, module, or an object being imported.

--- a/pazel/parse_imports.py
+++ b/pazel/parse_imports.py
@@ -11,7 +11,7 @@ from pazel.helpers import contains_python_file
 from pazel.helpers import is_installed
 
 
-def get_imports(script_source):
+def get_imports(script_source, script_package):
     """Parse imported packages and objects imported from packages.
 
     Args:
@@ -29,7 +29,12 @@ def get_imports(script_source):
     for node in ast_of_source.body:
         # Parse expressions of the form "from X import Y".
         if isinstance(node, ast.ImportFrom):
-            module = node.module
+            if node.level > 0:
+                # Normalize relative imports into absolute imports.
+                base_module_path = script_package.split(".")
+                module = ".".join(base_module_path[:len(base_module_path) - node.level]) + "." + node.module
+            else:
+                module = node.module
 
             for name in node.names:
                 from_imports.append((module, name.name))

--- a/pazel/parse_imports.py
+++ b/pazel/parse_imports.py
@@ -32,7 +32,14 @@ def get_imports(script_source, script_package):
             if node.level > 0:
                 # Normalize relative imports into absolute imports.
                 base_module_path = script_package.split(".")
-                module = ".".join(base_module_path[:len(base_module_path) - node.level]) + "." + node.module
+                relative_module_path = (
+                    node.module.split(".") if node.module else []
+                )
+                full_module_path = (
+                    base_module_path[:len(base_module_path) - node.level] +
+                    relative_module_path
+                )
+                module = ".".join(full_module_path)
             else:
                 module = node.module
 

--- a/sample_app/foo/BUILD
+++ b/sample_app/foo/BUILD
@@ -29,7 +29,10 @@ py_library(
 py_binary(
     name = "bar3",
     srcs = ["bar3.py"],
-    deps = ["//foo:bar2"],
+    deps = [
+        "//foo:__init__",
+        "//foo:bar2",
+    ],
 )
 
 py_library(

--- a/sample_app/foo/BUILD
+++ b/sample_app/foo/BUILD
@@ -29,6 +29,7 @@ py_library(
 py_binary(
     name = "bar3",
     srcs = ["bar3.py"],
+    deps = ["//foo:bar2"],
 )
 
 py_library(

--- a/sample_app/foo/bar3.py
+++ b/sample_app/foo/bar3.py
@@ -2,10 +2,12 @@ from __future__ import print_function
 
 import time
 from .bar2 import increment_sample
+from . import sample
 
 
 def main():
     print("Hello pazel.")
+    sample()
     increment_sample()
 
 

--- a/sample_app/foo/bar3.py
+++ b/sample_app/foo/bar3.py
@@ -1,10 +1,12 @@
 from __future__ import print_function
 
 import time
+from .bar2 import increment_sample
 
 
 def main():
     print("Hello pazel.")
+    increment_sample()
 
 
 main()


### PR DESCRIPTION
Process relative imports and transform into absolute imports in get_imports(), which allows
pazel to correctly generate deps for such imports.

Add bazel outputs to .gitignore